### PR TITLE
Remove dependency ordering requirement

### DIFF
--- a/src/main/groovy/io/dotinc/gradle/CodeGenPlugin.groovy
+++ b/src/main/groovy/io/dotinc/gradle/CodeGenPlugin.groovy
@@ -95,12 +95,13 @@ class CodeGenPlugin implements Plugin<Project> {
     private String getDependencyVersion(Project project, String dependency) {
         def vertxConfiguredVersion = project.extensions.getByName("codeGen").vertxVersion
 
-        def maybeVersion = project.configurations.collect { it -> it.dependencies }
-                .find { it -> it.name.contains(dependency) }
+        def maybeVersion = project.configurations.collect { it.dependencies }
+                .flatten()
+                .find { it.name == dependency }
         if (maybeVersion == null) {
             return vertxConfiguredVersion
         }
-        return StringUtil.isEmpty(maybeVersion.first().version) ? vertxConfiguredVersion : maybeVersion.first().version
+        return StringUtil.isEmpty(maybeVersion.version) ? vertxConfiguredVersion : maybeVersion.version
     }
 
 


### PR DESCRIPTION
Currently, the plugin requires vertx-core to be the first dependency defined in the `project.dependencies` section, in order to retrieve the version of Vert.x used in a build script. If this requirement is not satisfied, `0.0.1-SNAPSHOT` is used by default as shown in the error snippet below.
This PR removes that requirement.


```
> Configure project :
adding following dependencies to the project :
compileOnly ('io.vertx:vertx-core:0.0.1-SNAPSHOT')
compileOnly ('io.vertx:vertx-service-proxy:0.0.1-SNAPSHOT')
annotationProcessor ('io.vertx:vertx-service-proxy:0.0.1-SNAPSHOT:processor')
compileOnly ('io.vertx:vertx-codegen:0.0.1-SNAPSHOT')
annotationProcessor ('io.vertx:vertx-codegen:0.0.1-SNAPSHOT:processor')

> Task :extractIncludeProto
> Task :extractProto
> Task :generateProto
> Task :compileJava FAILED

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings
4 actionable tasks: 4 executed

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':annotationProcessor'.
   > Could not find io.vertx:vertx-service-proxy:0.0.1-SNAPSHOT.
     Searched in the following locations:
       - file:~/.m2/repository/io/vertx/vertx-service-proxy/0.0.1-SNAPSHOT/maven-metadata.xml
       - file:~/.m2/repository/io/vertx/vertx-service-proxy/0.0.1-SNAPSHOT/vertx-service-proxy-0.0.1-SNAPSHOT.pom
       - https://jcenter.bintray.com/io/vertx/vertx-service-proxy/0.0.1-SNAPSHOT/maven-metadata.xml
       - https://jcenter.bintray.com/io/vertx/vertx-service-proxy/0.0.1-SNAPSHOT/vertx-service-proxy-0.0.1-SNAPSHOT.pom
     Required by:
         project :

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 7s